### PR TITLE
feat(email): Implemented an email validator in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +50,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -168,6 +183,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +257,7 @@ name = "validx"
 version = "0.1.0"
 dependencies = [
  "pyo3",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = "0.18.1"
+regex = "1.10.2"
+

--- a/src/email_valid.rs
+++ b/src/email_valid.rs
@@ -1,0 +1,20 @@
+use pyo3::prelude::*;
+use regex::Regex;
+
+#[pyfunction]
+pub fn email(email: String) -> PyResult<bool> {
+    // The maximum length of an email is 320 characters per RFC 3696
+    // section 3.
+    if !email.contains("@") || email.len() > 320 {
+        return Ok(false);
+    }
+
+    // TODO: use more complex regex
+    // https://github.com/python-validators/validators/blob/master/src/validators/email.py
+    let re = Regex::new(r"^[\w\.-]+@[a-zA-Z\d\.-]+\.[a-zA-Z]{2,}$").unwrap();
+
+    if re.is_match(&email) {
+        return Ok(true);
+    }
+    return Ok(false);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod country_code_valid;
+pub mod email_valid;
 
-use pyo3::prelude::*;
 use country_code_valid::country_code;
-
+use email_valid::email;
+use pyo3::prelude::*;
 
 #[pymodule]
 fn validx(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(country_code, m)?)?;
+    m.add_function(wrap_pyfunction!(email, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
## Pull Request: Email Validator

### Changes Made
- Implemented an email validator in Rust.

### Description
I have added a Rust implementation for email validation. The validator checks if the given email adheres to a basic structure. It uses a regular expression for this purpose, ensuring that the email format includes a local part, the '@' symbol, and a domain part.

### Motivation
Email validation is a common task in many applications, and having a reliable and efficient validator in Rust can be beneficial for projects dealing with user input or data processing.

Fix: #2