### PR TITLE
 feat(hashes): 🚀 md5,sha1,sha224,sha256,sha512 validators and tests are added.

### DIFF
--- a/src/hashes_valid.rs
+++ b/src/hashes_valid.rs
@@ -1,0 +1,14 @@
+use pyo3::prelude::*;
+use regex::Regex;
+
+#[pyfunction]
+pub fn md5_hash(md5_hash: String) -> PyResult<bool> {
+    // The maximum length of an email is 320 characters per RFC 3696
+
+    let re:Regex = Regex::new(r"^[0-9a-f]{32}$").unwrap();
+
+    if re.is_match(&md5_hash) {
+        return Ok(true);
+    }
+    return Ok(false);
+}

--- a/src/hashes_valid.rs
+++ b/src/hashes_valid.rs
@@ -7,7 +7,7 @@ pub fn md5(value: String) -> PyResult<bool> {
 
     let re: Regex = Regex::new(r"^[0-9a-f]{32}$").unwrap();
 
-    if re.is_match(&value) {
+    if re.is_match(&value.to_lowercase()) {
         return Ok(true);
     }
     return Ok(false);
@@ -17,7 +17,7 @@ pub fn md5(value: String) -> PyResult<bool> {
 pub fn sha1(value: String) -> PyResult<bool> {
     let re: Regex = Regex::new(r"^[0-9a-f]{40}$").unwrap();
 
-    if re.is_match(&value) {
+    if re.is_match(&value.to_lowercase()) {
         return Ok(true);
     }
     return Ok(false);

--- a/src/hashes_valid.rs
+++ b/src/hashes_valid.rs
@@ -2,13 +2,45 @@ use pyo3::prelude::*;
 use regex::Regex;
 
 #[pyfunction]
-pub fn md5_hash(md5_hash: String) -> PyResult<bool> {
+pub fn md5(value: String) -> PyResult<bool> {
     // The maximum length of an email is 320 characters per RFC 3696
 
-    let re:Regex = Regex::new(r"^[0-9a-f]{32}$").unwrap();
+    let re: Regex = Regex::new(r"^[0-9a-f]{32}$").unwrap();
 
-    if re.is_match(&md5_hash) {
+    if re.is_match(&value) {
         return Ok(true);
     }
+    return Ok(false);
+}
+
+#[pyfunction]
+pub fn sha1(value: String) -> PyResult<bool> {
+    let re: Regex = Regex::new(r"^[0-9a-f]{40}$").unwrap();
+
+    if re.is_match(&value) {
+        return Ok(true);
+    }
+    return Ok(false);
+}
+
+#[pyfunction]
+pub fn sha224(value: String) -> PyResult<bool> {
+    let re: Regex = Regex::new(r"^[0-9a-f]{56}$").unwrap();
+
+    if re.is_match(&value) {
+        return Ok(true);
+    }
+
+    return Ok(false);
+}
+
+#[pyfunction]
+pub fn sha256(value: String) -> PyResult<bool> {
+    let re: Regex = Regex::new(r"^[0-9a-f]{64}$").unwrap();
+
+    if re.is_match(&value) {
+        return Ok(true);
+    }
+
     return Ok(false);
 }

--- a/src/hashes_valid.rs
+++ b/src/hashes_valid.rs
@@ -27,7 +27,7 @@ pub fn sha1(value: String) -> PyResult<bool> {
 pub fn sha224(value: String) -> PyResult<bool> {
     let re: Regex = Regex::new(r"^[0-9a-f]{56}$").unwrap();
 
-    if re.is_match(&value) {
+    if re.is_match(&value.to_lowercase()) {
         return Ok(true);
     }
 
@@ -38,7 +38,18 @@ pub fn sha224(value: String) -> PyResult<bool> {
 pub fn sha256(value: String) -> PyResult<bool> {
     let re: Regex = Regex::new(r"^[0-9a-f]{64}$").unwrap();
 
-    if re.is_match(&value) {
+    if re.is_match(&value.to_lowercase()) {
+        return Ok(true);
+    }
+
+    return Ok(false);
+}
+
+#[pyfunction]
+pub fn sha512(value: String) -> PyResult<bool> {
+    let re: Regex = Regex::new(r"^[0-9a-f]{128}$").unwrap();
+
+    if re.is_match(&value.to_lowercase()) {
         return Ok(true);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod ip_address_valid;
 
 use country_code_valid::country_code;
 use email_valid::email;
-use hashes_valid::{md5, sha1, sha224, sha256};
+use hashes_valid::{md5, sha1, sha224, sha256, sha512};
 use ip_address_valid::ip_address;
 use pyo3::prelude::*;
 
@@ -18,5 +18,6 @@ fn validx(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sha1, m)?)?;
     m.add_function(wrap_pyfunction!(sha224, m)?)?;
     m.add_function(wrap_pyfunction!(sha256, m)?)?;
+    m.add_function(wrap_pyfunction!(sha512, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod country_code_valid;
 pub mod email_valid;
 pub mod ip_address_valid;
+pub mod hashes_valid;
 
 use country_code_valid::country_code;
 use email_valid::email;
 use ip_address_valid::ip_address;
+use hashes_valid::md5_hash;
 use pyo3::prelude::*;
 
 #[pymodule]
@@ -12,5 +14,6 @@ fn validx(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(country_code, m)?)?;
     m.add_function(wrap_pyfunction!(email, m)?)?;
     m.add_function(wrap_pyfunction!(ip_address, m)?)?;
+    m.add_function(wrap_pyfunction!(md5_hash, m)?)?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 pub mod country_code_valid;
 pub mod email_valid;
-pub mod ip_address_valid;
 pub mod hashes_valid;
+pub mod ip_address_valid;
 
 use country_code_valid::country_code;
 use email_valid::email;
+use hashes_valid::{md5, sha1, sha224, sha256};
 use ip_address_valid::ip_address;
-use hashes_valid::md5_hash;
 use pyo3::prelude::*;
 
 #[pymodule]
@@ -14,6 +14,9 @@ fn validx(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(country_code, m)?)?;
     m.add_function(wrap_pyfunction!(email, m)?)?;
     m.add_function(wrap_pyfunction!(ip_address, m)?)?;
-    m.add_function(wrap_pyfunction!(md5_hash, m)?)?;
+    m.add_function(wrap_pyfunction!(md5, m)?)?;
+    m.add_function(wrap_pyfunction!(sha1, m)?)?;
+    m.add_function(wrap_pyfunction!(sha224, m)?)?;
+    m.add_function(wrap_pyfunction!(sha256, m)?)?;
     Ok(())
 }

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -1,0 +1,16 @@
+import validx
+import pytest
+
+
+@pytest.mark.parametrize(
+    "hash, expected",
+    [
+        ("da39a3ee5e6b4b0d3255bfef95601890afd80709", True),
+        ("DA39A3EE5E6B4B0D3255BFEF95601890AFD80709", True),
+        ("za39a3ee5e6b4b0d3255bfef95601890afd80709", False),
+        ("da39e5e6b4b0d3255bfef95601890afd80709", False),
+        ("daaaa39a3ee5e6b4b0d3255bfef95601890afd80709", False),
+    ],
+)
+def test_sha1(hash: str, expected: bool):
+    assert validx.sha1(hash) == expected

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -2,6 +2,26 @@ import validx
 import pytest
 
 
+# test md5
+@pytest.mark.parametrize(
+    "hash, expected",
+    [
+        ("d41d8cd98f00b204e9800998ecf8427e", True),
+        ("098f6bcd4621d373cade4e832627b4f6", True),
+        ("5d41402abc4b2a76b9719d911017c592", True),
+        ("7dcd4ce23d88e2ee95838f7b014b6284", True),
+        ("6dcd4ce23d88e2ee95838f7b014b6284", True),
+        ("1234567890abcdefg1234567890abcdefg", False),
+        ("abcdefg1234567890abcdefg1234567890", False),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
+        ("abcdefg1234567890abcdefg1234567890abcdefg1234567890", False),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
+    ],
+)
+def test_md5(hash: str, expected: bool):
+    assert validx.md5(hash) == expected
+
+
 @pytest.mark.parametrize(
     "hash, expected",
     [
@@ -10,7 +30,92 @@ import pytest
         ("za39a3ee5e6b4b0d3255bfef95601890afd80709", False),
         ("da39e5e6b4b0d3255bfef95601890afd80709", False),
         ("daaaa39a3ee5e6b4b0d3255bfef95601890afd80709", False),
+        ("5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8", True),
+        ("2aae6c35c94fcfb415dbe95f408b9ce91ee846ed", True),
+        ("3ca25ae354e192b26879f651a51d92aa8a34d8d3", True),
+        ("1234567890abcdefg1234567890abcdefg1234567890", False),
+        ("abcdefg1234567890abcdefg1234567890abcdefg1234567890", False),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
     ],
 )
 def test_sha1(hash: str, expected: bool):
     assert validx.sha1(hash) == expected
+
+
+# test sha224
+@pytest.mark.parametrize(
+    "hash, expected",
+    [
+        ("40997ec67c716eb08a4506df950cf3fec202edf2590c7cfe88456990", True),
+        ("90a69457550f15e6b468b8c5ed4c2a456524e8e8e61e9a57e10ab8a4", True),
+        ("a0a2b3c4d5e6f7081920a1b2c3d4e5f6a0a2b3c4d5e6f7081920a1b2", True),
+        ("b1b2c3d4e5f6a7b8c9d0a1b2c3d4e5f6a7b8c9d0a1b2c3d4", False),
+        ("d3e4f5a6b7c8d9e0a1b2c3d4e5f6a7b8c9d0a1b2c3d4e5", False),
+        ("1234567890abcdefg", False),
+        ("abcdefg1234567890", False),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
+        ("abcdefg1234567890abcdefg1234567890abcdefg1234567890", False),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
+    ],
+)
+def test_sha224(hash: str, expected: bool):
+    assert validx.sha224(hash) == expected
+
+
+# test sha256
+@pytest.mark.parametrize(
+    "hash, expected",
+    [
+        ("6dcd4ce23d88e2ee95838f7b014b6284ffdb5a5a7b42c4a6e38e4e4f0a6d1df5", True),
+        ("3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d", True),
+        ("6dcd4ce23d88e2ee95838f7b014b6284ffdb5a5a7b42c4a6e38e4e4f0a6d1df6", True),
+        ("1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg", False),
+        ("abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890", False),
+        (
+            "1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+    ],
+)
+def test_sha256(hash: str, expected: bool):
+    assert validx.sha256(hash) == expected
+
+
+# test sha512
+@pytest.mark.parametrize(
+    "hash, expected",
+    [
+        (
+            "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3aef53f2385d66c10c",
+            True,
+        ),
+        (
+            "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
+            True,
+        ),
+        ("d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592", False),
+        ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", False),
+        (
+            "1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+        (
+            "abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+        (
+            "1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+        (
+            "abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+        (
+            "1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg1234567890abcdefg",
+            False,
+        ),
+    ],
+)
+def test_sha512(hash: str, expected: bool):
+    assert validx.sha512(hash) == expected


### PR DESCRIPTION

### Description

This pull request introduces new features to the project. It adds validators and tests for MD5, SHA1, SHA224, SHA256 and SHA512 hashes.

The new validators are implemented as Python functions in the hashes_valid.rs file. Each function takes a string as input and returns a boolean indicating whether the string is a valid hash of the corresponding type. The validation is done using regular expressions.

The tests for these validators are implemented using the pytest framework. For each hash type, we have added tests with both valid and invalid hashes to ensure that the validators are working correctly.

This feature will enhance the project's capabilities in handling and validating different types of hashes, providing a robust and reliable solution for hash validation.

### Changes include:

- [X] Added md5 validator and tests
- [X] Added sha1 validator and tests
- [X] Added sha224 validator and tests
- [X] Added sha256 validator and tests
- [X] Added sha512 validator and tests


Please review the changes and let me know if any modifications are required.